### PR TITLE
Adds a synchronization demo

### DIFF
--- a/basic-threads/src/main/java/com/mikusa/BasicThreads.java
+++ b/basic-threads/src/main/java/com/mikusa/BasicThreads.java
@@ -2,7 +2,6 @@ package com.mikusa;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalTime;
 import java.util.Optional;
 
 public class BasicThreads {
@@ -38,8 +37,14 @@ public class BasicThreads {
 
         if (t.isPresent()) {
             Thread.sleep(2 * 1000);
+
             System.out.println("Interrupting");
+            // We are requesting that the thread interrupt
             t.get().interrupt();
+
+            // Then waiting until the thread actually stops
+            // If it interrupts properly, that'll happen almost immediately
+            // If it does not interrupt properly, it'll wait the full 100s instead of 2s
             t.get().join();
             System.out.println("Done");
         }
@@ -85,6 +90,7 @@ public class BasicThreads {
                     System.out.println("Sleeping for 10s");
                     Thread.sleep(10 * 1000);
                 } catch (InterruptedException e) {
+                    // If we remove this break, then the interrupt does nothing
                     break; // or return
                 }
             }

--- a/basic-threads/src/main/java/com/mikusa/CountRunnableTask.java
+++ b/basic-threads/src/main/java/com/mikusa/CountRunnableTask.java
@@ -11,6 +11,7 @@ public class CountRunnableTask implements Runnable {
                 System.out.println("Sleeping for 10s");
                 Thread.sleep(10 * 1000);
             } catch (InterruptedException e) {
+                // If we remove this break, then the interrupt does nothing
                 break; // or return
             }
         }

--- a/basic-threads/src/main/java/com/mikusa/CountThreadTask.java
+++ b/basic-threads/src/main/java/com/mikusa/CountThreadTask.java
@@ -10,6 +10,7 @@ public class CountThreadTask extends Thread {
                 System.out.println("Sleeping for 10s");
                 Thread.sleep(10 * 1000);
             } catch (InterruptedException e) {
+                // If we remove this break, then the interrupt does nothing
                 break; // or return
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
   <modules>
     <module>basic-threads</module>
+    <module>synchronization</module>
   </modules>
 
   <properties>

--- a/synchronization/pom.xml
+++ b/synchronization/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.mikusa</groupId>
+    <artifactId>java-concurrency-demo</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>synchronization</artifactId>
+  <name>Basic Synchronization Demo</name>
+  <packaging>jar</packaging>
+
+  <properties></properties>
+
+  <dependencies></dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.mikusa.Synchronization</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/synchronization/src/main/java/com/mikusa/BlockSyncCounter.java
+++ b/synchronization/src/main/java/com/mikusa/BlockSyncCounter.java
@@ -1,0 +1,27 @@
+package com.mikusa;
+
+public class BlockSyncCounter implements SyncCounter {
+    private int count;
+
+    @Override
+    public void increment() {
+        synchronized (this) {
+            count += 1;
+        }
+    }
+
+    @Override
+    public void decrement() {
+        synchronized (this) {
+            count -= 1;
+        }
+    }
+
+    @Override
+    public int getCount() {
+        synchronized (this) {
+            return count;
+        }
+    }
+
+}

--- a/synchronization/src/main/java/com/mikusa/MethodSyncCounter.java
+++ b/synchronization/src/main/java/com/mikusa/MethodSyncCounter.java
@@ -1,0 +1,17 @@
+package com.mikusa;
+
+public class MethodSyncCounter implements SyncCounter {
+    private int count = 0;
+
+    public synchronized void increment() {
+        count += 1;
+    }
+
+    public synchronized void decrement() {
+        count -= 1;
+    }
+
+    public synchronized int getCount() {
+        return count;
+    }
+}

--- a/synchronization/src/main/java/com/mikusa/NoSyncCounter.java
+++ b/synchronization/src/main/java/com/mikusa/NoSyncCounter.java
@@ -1,0 +1,21 @@
+package com.mikusa;
+
+public class NoSyncCounter implements SyncCounter {
+    private int counter = 0;
+
+    @Override
+    public void increment() {
+        counter += 1;
+    }
+
+    @Override
+    public void decrement() {
+        counter -= 1;
+    }
+
+    @Override
+    public int getCount() {
+        return counter;
+    }
+
+}

--- a/synchronization/src/main/java/com/mikusa/SyncCounter.java
+++ b/synchronization/src/main/java/com/mikusa/SyncCounter.java
@@ -1,0 +1,9 @@
+package com.mikusa;
+
+public interface SyncCounter {
+    void increment();
+
+    void decrement();
+
+    int getCount();
+}

--- a/synchronization/src/main/java/com/mikusa/Synchronization.java
+++ b/synchronization/src/main/java/com/mikusa/Synchronization.java
@@ -1,0 +1,105 @@
+package com.mikusa;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Synchronization {
+    public static void main(String[] args) throws InterruptedException {
+        if (args.length == 0) {
+            System.out.println("USAGE:");
+            System.out.println("    java com.mikusa.Synchronization <type>");
+            System.out.println();
+            System.out.println("Types: `no-sync`, `volatile`, `sync-method` or `sync-block`");
+            System.out.println();
+            System.exit(1);
+        }
+
+        Instant start = Instant.now();
+
+        switch (args[0]) {
+            case "sync-method":
+                runSyncMethod();
+                break;
+            case "sync-block":
+                runSyncBlock();
+                break;
+            case "no-sync":
+                runNoSync();
+                break;
+            case "volatile":
+                runVolatileSync();
+                break;
+            default:
+                System.out.println("Invalid option [" + args[0] + "]");
+        }
+
+        System.out.println("Acutal run time: " + Duration.between(start, Instant.now()));
+    }
+
+    /*
+     * Uses a method-based synchronization counter
+     * 
+     */
+    private static void runSyncMethod() {
+        MethodSyncCounter counter = new MethodSyncCounter();
+        runCounter(counter);
+    }
+
+    /*
+     * Uses a block-based synchronization counter
+     *
+     */
+    private static void runSyncBlock() {
+        BlockSyncCounter counter = new BlockSyncCounter();
+        runCounter(counter);
+    }
+
+    /*
+     * Uses no synchronization in the counter
+     *
+     */
+    private static void runNoSync() {
+        NoSyncCounter counter = new NoSyncCounter();
+        runCounter(counter);
+    }
+
+    /*
+     * Uses volatile on the synchronization counter
+     *
+     */
+    private static void runVolatileSync() {
+        VolatileSyncCounter counter = new VolatileSyncCounter();
+        runCounter(counter);
+    }
+
+    /*
+     * Count to a million across 10 threads
+     * 
+     * Uses a counter which synchronizes on method calls.
+     *
+     */
+    private static void runCounter(SyncCounter counter) {
+        List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            Thread t = new Thread(() -> {
+                for (int j = 0; j < 100_000; j++) {
+                    counter.increment();
+                }
+            });
+            t.start();
+            threads.add(t);
+        }
+
+        for (Thread t : threads) {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+            }
+        }
+
+        System.out.println("Total Count: " + counter.getCount());
+    }
+}

--- a/synchronization/src/main/java/com/mikusa/VolatileSyncCounter.java
+++ b/synchronization/src/main/java/com/mikusa/VolatileSyncCounter.java
@@ -1,0 +1,21 @@
+package com.mikusa;
+
+public class VolatileSyncCounter implements SyncCounter {
+    private volatile int counter = 0;
+
+    @Override
+    public void increment() {
+        counter += 1;
+    }
+
+    @Override
+    public void decrement() {
+        counter -= 1;
+    }
+
+    @Override
+    public int getCount() {
+        return counter;
+    }
+
+}


### PR DESCRIPTION
Includes four different counters: no-sync, volatile, method sync and block sync. The demo makes 10 threads and counts to one million. The no-sync/volatile demos don't provide mutual exclusion while incrementing the counter, so the end result is a count that's incorrect. The synchronized demos do provide mutual exclusion while incrementing the counter so they count correctly. There's little difference between the method or block synchronization in this demo, but block level synchronization can be more efficient in some cases.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>